### PR TITLE
Add RHEL support & fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ ENV TZ=Etc/UTC
 RUN add-apt-repository -y ppa:deadsnakes/ppa && apt-get update \
     && apt-get install -y python3.9-dev python3.9-distutils python3.9
 
-RUN apt-get install -y python3-dev python3-distutils
-
 WORKDIR /app
 RUN git clone https://github.com/PotatoSpudowski/fastLLaMa.git /app
 RUN chmod +x build.sh && bash ./build.sh

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,9 @@ ifeq ($(UNAME_M),$(filter $(UNAME_M),x86_64 i686))
 		ifneq (,$(findstring avx512pf,$(AVX512PF_M)))
 			CFLAGS += -mavx512pf
 		endif
+		ifneq (,$(findstring Red Hat,$(CXXV)))
+			CFLAGS += -D_POSIX_C_SOURCE=199309L
+		endif
 	else ifeq ($(UNAME_S),Haiku)
 		AVX1_M := $(shell sysinfo -cpu | grep -w "AVX")
 		ifneq (,$(findstring AVX,$(AVX1_M)))

--- a/README.md
+++ b/README.md
@@ -160,42 +160,42 @@ and sufficient RAM to load them. At the moment, memory and disk requirements are
 
 ### Example Dockerfile
 This is a Dockerfile to build a minimal working example. Note that it does not download any models for you. It is also compatible with Alpaca models.
-    
-    FROM ubuntu:18.04
-    # Add GCC and G++ New
-    RUN apt-get update && apt-get install software-properties-common curl git -qy 
-    RUN add-apt-repository ppa:ubuntu-toolchain-r/test && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 42D5A192B819C5DA
 
-    # Add CMAKE New
-    RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-    RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ bionic main" && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6AF7F09730B3F0A4
+```dockerfile 
+FROM ubuntu:18.04
+# Add GCC and G++ New
+RUN apt-get update && apt-get install software-properties-common curl git -qy 
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 42D5A192B819C5DA
 
-    RUN apt-get update
+# Add CMAKE New
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ bionic main" && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6AF7F09730B3F0A4
 
-    # Install
-    RUN apt-get install -qy cmake gcc-10 g++-10
+RUN apt-get update
 
-    # Configure
-    RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 30 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 30
-    RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30 && update-alternatives --set cc /usr/bin/gcc
-    RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30 && update-alternatives --set c++ /usr/bin/g++
+# Install
+RUN apt-get install -qy cmake gcc-10 g++-10
 
-    ARG DEBIAN_FRONTEND=noninteractive
-    ENV TZ=Etc/UTC
-    RUN add-apt-repository -y ppa:deadsnakes/ppa && apt-get update \
-        && apt-get install -y python3.9-dev python3.9-distutils python3.9
+# Configure
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 30 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 30
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30 && update-alternatives --set cc /usr/bin/gcc
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30 && update-alternatives --set c++ /usr/bin/g++
 
-    RUN apt-get install -y python3-dev python3-distutils
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+RUN add-apt-repository -y ppa:deadsnakes/ppa && apt-get update \
+    && apt-get install -y python3.9-dev python3.9-distutils python3.9
 
-    WORKDIR /app
-    RUN git clone https://github.com/PotatoSpudowski/fastLLaMa.git /app
-    RUN chmod +x build.sh && bash ./build.sh
+WORKDIR /app
+RUN git clone https://github.com/PotatoSpudowski/fastLLaMa.git /app
+RUN chmod +x build.sh && bash ./build.sh
 
-    RUN apt-get install -qy python3-pip
-    RUN python3.9 -m pip install --upgrade pip && python3.9 -m pip install setuptools-rust
-    RUN python3.9 -m pip install -r requirements.txt
+RUN apt-get install -qy python3-pip
+RUN python3.9 -m pip install --upgrade pip && python3.9 -m pip install setuptools-rust
+RUN python3.9 -m pip install -r requirements.txt
 
-    CMD ["python3.9", "example.py"]
+CMD ["python3.9", "example.py"]
+```
 
 ### Notes
 * Tested on 


### PR DESCRIPTION
Added the CentOS (Red Hat) line extracted from Build Info. Maybe in the future other distros will face the same issue, so adding either more distros or generalizing it will be required. I also fixed the Dockerfile in Readme, and I removed an unncessary line (installing python3 after it's already installed).