### PR TITLE
Remove redundent pointer transform that could introduce bug

### DIFF
--- a/bridge.cpp
+++ b/bridge.cpp
@@ -1024,7 +1024,6 @@ private:
         file.write(reinterpret_cast<char const*>(&m_model.hparams), sizeof(m_model.hparams));
 
         auto const save_tensor = [this, &file](ggml_tensor* t) {
-            transform_tensors_to_relative_ptr(*t);
             save_value(file, get_relative_ptr(t));
             transform_tensors_to_resolved_ptr(*t);
         };


### PR DESCRIPTION
We were transforming the same pointer twice but transforming it back once might have introduced a bug in the loading and saving state.